### PR TITLE
feat: add certificate generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "exifr": "^7.1.3",
         "next": "15.5.2",
         "onnxruntime-web": "^1.19.0",
+        "pdf-lib": "^1.17.1",
         "react": "19.1.0",
         "react-dom": "19.1.0"
       },
@@ -949,6 +950,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -5009,6 +5028,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5048,6 +5073,24 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "exifr": "^7.1.3",
     "next": "15.5.2",
     "onnxruntime-web": "^1.19.0",
+    "pdf-lib": "^1.17.1",
     "react": "19.1.0",
     "react-dom": "19.1.0"
   },

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -88,7 +88,7 @@ export default function ImageUploader({ onFileSelect, maxSizeMB = 5 }: ImageUplo
           className="mt-4 rounded object-contain"
         />
       )}
-      <ResultPanel result={result} loading={loading} onReset={handleReset} />
+      <ResultPanel result={result} loading={loading} onReset={handleReset} image={preview} />
       <p className="mt-2 text-xs text-gray-500">No data leaves your device</p>
     </div>
   );

--- a/src/components/ResultPanel.tsx
+++ b/src/components/ResultPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { generateCertificate } from '../utils/generateCertificate';
 
 interface WorkerResult {
   probability: number;
@@ -15,9 +16,10 @@ interface ResultPanelProps {
   result: WorkerResult | null;
   loading: boolean;
   onReset: () => void;
+  image: string | null;
 }
 
-export default function ResultPanel({ result, loading, onReset }: ResultPanelProps) {
+export default function ResultPanel({ result, loading, onReset, image }: ResultPanelProps) {
   if (loading) {
     return (
       <div className="mt-4 text-sm text-gray-500">Analyzing...</div>
@@ -38,13 +40,22 @@ export default function ResultPanel({ result, loading, onReset }: ResultPanelPro
         Overall Confidence: {(result.probability * 100).toFixed(2)}%
       </p>
       <p className="font-semibold">Verdict: {verdict}</p>
-      <button
-        type="button"
-        onClick={onReset}
-        className="mt-4 rounded bg-gray-200 px-4 py-2 text-gray-800 hover:bg-gray-300"
-      >
-        Clear
-      </button>
+      <div className="mt-4 flex gap-2">
+        <button
+          type="button"
+          onClick={() => image && generateCertificate(image, result)}
+          className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+        >
+          Download Certificate
+        </button>
+        <button
+          type="button"
+          onClick={onReset}
+          className="rounded bg-gray-200 px-4 py-2 text-gray-800 hover:bg-gray-300"
+        >
+          Clear
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/utils/generateCertificate.ts
+++ b/src/utils/generateCertificate.ts
@@ -1,0 +1,118 @@
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+
+interface WorkerResult {
+  probability: number;
+  cameraInfoPresent: boolean;
+  frequencySpectrum: number;
+  noiseResidual: number;
+  colorHistogram: number;
+  finalVerdict: string;
+}
+
+export async function generateCertificate(imageDataUrl: string, result: WorkerResult) {
+  const pdfDoc = await PDFDocument.create();
+  const page = pdfDoc.addPage([595, 842]); // A4 size
+  const { width, height } = page.getSize();
+
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+
+  // Logo
+  try {
+    const logoBytes = await fetch('/logo.png').then((res) => res.arrayBuffer());
+    const logoImage = await pdfDoc.embedPng(logoBytes);
+    const logoDims = logoImage.scale(0.5);
+    page.drawImage(logoImage, {
+      x: 40,
+      y: height - logoDims.height - 40,
+      width: logoDims.width,
+      height: logoDims.height,
+    });
+  } catch {
+    // ignore
+  }
+
+  page.drawText('IsItAI Analysis Certificate', {
+    x: 200,
+    y: height - 60,
+    size: 18,
+    font,
+  });
+
+  // Uploaded image
+  const imgBytes = await fetch(imageDataUrl).then((res) => res.arrayBuffer());
+  let embeddedImg;
+  if (imageDataUrl.startsWith('data:image/png')) {
+    embeddedImg = await pdfDoc.embedPng(imgBytes);
+  } else {
+    embeddedImg = await pdfDoc.embedJpg(imgBytes);
+  }
+  const imgWidth = 200;
+  const imgHeight = (embeddedImg.height / embeddedImg.width) * imgWidth;
+  page.drawImage(embeddedImg, {
+    x: 40,
+    y: height - imgHeight - 120,
+    width: imgWidth,
+    height: imgHeight,
+  });
+
+  // Parameter table
+  const params = [
+    ['Frequency Spectrum', result.frequencySpectrum.toFixed(2)],
+    ['Noise Residual', result.noiseResidual.toFixed(2)],
+    ['Color Histogram', result.colorHistogram.toFixed(2)],
+    ['Camera Info Present', result.cameraInfoPresent ? 'Yes' : 'No'],
+    ['Overall Confidence', `${(result.probability * 100).toFixed(2)}%`],
+  ];
+
+  let y = height - 150;
+  const lineHeight = 16;
+  params.forEach(([label, value]) => {
+    page.drawText(`${label}: ${value}`, {
+      x: 260,
+      y,
+      size: 12,
+      font,
+    });
+    y -= lineHeight;
+  });
+
+  const verdict = result.finalVerdict === 'AI-generated' ? 'AI Generated' : 'Real Photo';
+  page.drawText(`Verdict: ${verdict}`, {
+    x: 260,
+    y: y - lineHeight,
+    size: 12,
+    font,
+  });
+
+  // Timestamp
+  const timestamp = new Date().toLocaleString();
+  page.drawText(`Generated: ${timestamp}`, {
+    x: 40,
+    y: 60,
+    size: 10,
+    font,
+  });
+
+  // Signature
+  try {
+    const sigBytes = await fetch('/signature.png').then((res) => res.arrayBuffer());
+    const sigImage = await pdfDoc.embedPng(sigBytes);
+    const sigDims = sigImage.scale(0.5);
+    page.drawImage(sigImage, {
+      x: width - sigDims.width - 40,
+      y: 80,
+      width: sigDims.width,
+      height: sigDims.height,
+    });
+  } catch {
+    // ignore
+  }
+
+  const pdfBytes = await pdfDoc.save();
+  const blob = new Blob([pdfBytes], { type: 'application/pdf' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = 'IsItAI_Certificate.pdf';
+  link.click();
+  URL.revokeObjectURL(link.href);
+}


### PR DESCRIPTION
## Summary
- add pdf-lib and brand assets
- generate PDF certificate with metrics and signatures
- expose download action in result panel
- remove logo and signature assets from git so they can be uploaded separately

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bda0c4f9fc832282fe8770c17d41e2