### PR TITLE
feat: show analysis progress in console

### DIFF
--- a/src/components/ProgressConsole.tsx
+++ b/src/components/ProgressConsole.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+
+interface Step {
+  step: string;
+  progress: number;
+}
+
+export default function ProgressConsole({ steps }: { steps: Step[] }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [steps]);
+
+  return (
+    <div
+      ref={ref}
+      className="mt-4 h-32 w-full overflow-y-auto rounded bg-black p-2 font-mono text-green-400 text-sm"
+    >
+      {steps.map((s, i) => (
+        <p key={i} className="typing">
+          {s.step}
+        </p>
+      ))}
+      <style jsx>{`
+        .typing {
+          overflow: hidden;
+          white-space: nowrap;
+          animation: typing 0.8s steps(40, end);
+        }
+        @keyframes typing {
+          from { width: 0 }
+          to { width: 100% }
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- send progress updates from detector worker at key stages
- add animated ProgressConsole component
- track and display progress steps during image analysis

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdc71217288322a53adace1b21785c