### PR TITLE
refactor: centralize WorkerResult type

### DIFF
--- a/src/components/ResultPanel.tsx
+++ b/src/components/ResultPanel.tsx
@@ -1,15 +1,7 @@
 'use client';
 
 import React from 'react';
-
-interface WorkerResult {
-  probability: number;
-  cameraInfoPresent: boolean;
-  frequencySpectrum: number;
-  noiseResidual: number;
-  colorHistogram: number;
-  finalVerdict: string;
-}
+import type { WorkerResult } from '../types/worker';
 
 interface ResultPanelProps {
   result: WorkerResult | null;

--- a/src/types/worker.ts
+++ b/src/types/worker.ts
@@ -1,0 +1,9 @@
+export interface WorkerResult {
+  probability: number;
+  cameraInfoPresent: boolean;
+  frequencySpectrum: number;
+  noiseResidual: number;
+  colorHistogram: number;
+  finalVerdict: string;
+}
+

--- a/src/utils/generateCertificate.ts
+++ b/src/utils/generateCertificate.ts
@@ -1,14 +1,7 @@
 // Lazily load pdf-lib only when generating a certificate to avoid
 // pulling the heavy library into the initial bundle.
 
-interface WorkerResult {
-  probability: number;
-  cameraInfoPresent: boolean;
-  frequencySpectrum: number;
-  noiseResidual: number;
-  colorHistogram: number;
-  finalVerdict: string;
-}
+import type { WorkerResult } from '../types/worker';
 
 export async function generateCertificate(imageDataUrl: string, result: WorkerResult) {
   const { PDFDocument, StandardFonts } = await import('pdf-lib');
@@ -112,7 +105,7 @@ export async function generateCertificate(imageDataUrl: string, result: WorkerRe
   }
 
   const pdfBytes = await pdfDoc.save();
-  const blob = new Blob([pdfBytes], { type: 'application/pdf' });
+  const blob = new Blob([pdfBytes.buffer as ArrayBuffer], { type: 'application/pdf' });
   const link = document.createElement('a');
   link.href = URL.createObjectURL(blob);
   link.download = 'IsItAI_Certificate.pdf';

--- a/src/workers/detectorWorker.ts
+++ b/src/workers/detectorWorker.ts
@@ -1,5 +1,6 @@
 // Defer loading heavy libraries until the worker receives a message.
 import type * as ortTypes from 'onnxruntime-web';
+import type { WorkerResult } from '../types/worker';
 
 interface HeuristicScores {
   frequencySpectrum: number;
@@ -7,11 +8,6 @@ interface HeuristicScores {
   colorHistogram: number;
 }
 
-interface WorkerResult extends HeuristicScores {
-  probability: number;
-  cameraInfoPresent: boolean;
-  finalVerdict: string;
-}
 
 function toGrayscale(data: Uint8ClampedArray): Float32Array {
   const gray = new Float32Array(data.length / 4);


### PR DESCRIPTION
## Summary
- add shared `WorkerResult` interface
- use shared type in image uploader, result panel, certificate utils, and detector worker

## Testing
- `npx tsc --noEmit --lib dom,dom.iterable,esnext,webworker`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdcbcadbf48322840e618cab999a49