### PR TITLE
Add PWA manifest and service worker for offline caching

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "IsItAI",
+  "short_name": "IsItAI",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#4f46e5",
+  "icons": [
+    {
+      "src": "/logo.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Poppins, Roboto_Mono } from "next/font/google";
 import "./globals.css";
+import ServiceWorkerRegister from "./service-worker-register";
 
 const poppins = Poppins({
   variable: "--font-poppins",
@@ -16,6 +17,7 @@ const robotoMono = Roboto_Mono({
 export const metadata: Metadata = {
   title: "IsItAI",
   description: "Detect AI-generated images instantly.",
+  manifest: "/manifest.json",
   openGraph: {
     title: "IsItAI",
     description: "Detect AI-generated images instantly.",
@@ -45,6 +47,7 @@ export default function RootLayout({
         className={`${poppins.variable} ${robotoMono.variable} flex min-h-screen flex-col bg-white text-gray-900 antialiased dark:bg-gray-900 dark:text-gray-100 font-sans`}
       >
         {children}
+        <ServiceWorkerRegister />
         <footer className="mt-auto p-4 text-center text-xs text-gray-500 dark:text-gray-400">
           © {new Date().getFullYear()} IsItAI. All rights reserved.
         </footer>

--- a/src/app/service-worker-register.tsx
+++ b/src/app/service-worker-register.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function ServiceWorkerRegister() {
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker
+        .register("/service-worker.js")
+        .catch((err) => console.error("Service worker registration failed", err));
+    }
+  }, []);
+
+  return null;
+}

--- a/src/app/service-worker.ts
+++ b/src/app/service-worker.ts
@@ -1,0 +1,46 @@
+/// <reference lib="webworker" />
+
+const sw = self as unknown as ServiceWorkerGlobalScope;
+
+const CACHE_NAME = "isitai-cache-v1";
+const ASSETS = ["/models/mnist-8.onnx"];
+
+sw.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+  );
+});
+
+sw.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.map((key) => (key !== CACHE_NAME ? caches.delete(key) : Promise.resolve())))
+    )
+  );
+});
+
+sw.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (request.method !== "GET") return;
+
+  const url = new URL(request.url);
+  const sameOrigin = url.origin === sw.location.origin;
+
+  if (
+    url.pathname === "/models/mnist-8.onnx" ||
+    (sameOrigin &&
+      (url.pathname.startsWith("/_next/static/") ||
+        ["script", "style", "image", "font"].includes(request.destination)))
+  ) {
+    event.respondWith(
+      caches.match(request).then((cached) => {
+        if (cached) return cached;
+        return fetch(request).then((response) => {
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, responseClone));
+          return response;
+        });
+      })
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add `public/manifest.json` with basic app metadata and icon
- implement `app/service-worker.ts` to cache ONNX model, JS bundles, and static assets
- register the service worker from `layout.tsx`

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npx --yes lighthouse http://localhost:3000 --quiet --chrome-flags="--headless"` *(fails: The CHROME_PATH environment variable must be set)*


------
https://chatgpt.com/codex/tasks/task_e_68bdce6c1d0c832280ef183cdebf2a86